### PR TITLE
Enable Vulkan support on Linux and Windows to support non-Nvidia GPUs

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: llama.cpp
   version: "6441"
-  build: 0
+  build: 1
 
 package:
   name: ${{ name|lower }}
@@ -38,6 +38,12 @@ build:
         ${{ cmake_args("BUILD_SHARED_LIBS=ON") }}
         ${{ llama_args("CURL=ON") }}
 
+        # Vulkan is only useful on Linux, as on macOS
+        # metal is used
+        {%- if linux %}
+        ${{ ggml_args("VULKAN=ON") }}
+        {%- endif %}
+
         {%- if osx and arm64 %}
         ${{ ggml_args("NATIVE=OFF") }}
         ${{ ggml_args("AVX=OFF") }}
@@ -67,6 +73,11 @@ build:
 
         {%- endif %}
 
+        {%- if build_platform != target_platform %}
+        ${{ cmake_args("HOST_C_COMPILER=$CC_FOR_BUILD") }}
+        ${{ cmake_args("HOST_CXX_COMPILER=$CXX_FOR_BUILD") }}
+        {%- endif %}
+
         echo $LLAMA_ARGS
         cmake -S . -B build -G Ninja ${CMAKE_ARGS} ${LLAMA_ARGS}
         cmake --build build
@@ -92,6 +103,8 @@ build:
         ${{ llama_args("CURL=ON") }}
 
         ${{ ggml_args("NATIVE=OFF") }}
+
+        ${{ ggml_args("VULKAN=ON") }}
 
         {%- if cuda_compiler_version != "None" %}
         ${{ ggml_args("CUDA=ON") }}
@@ -137,6 +150,9 @@ requirements:
     - pkgconfig
   host:
     - libcurl
+    - libvulkan-headers
+    - libvulkan-loader
+    - shaderc
     - if: cuda_compiler_version != "None"
       then:
         # NOTE: Without cuda-version, we are installing cuda-toolkit 11.8 instead of 11.2!


### PR DESCRIPTION
This PR enables Vulkan support in all builds. With just an additional ~5 MB more, we can a package that can use GPU also on non-Nvidia GPUs (I tested just on an integrated Intel GPU and the perfomance are not at the level of CUDA, but definitely better then CPU).

For example, on my testing machine Windows laptop with NVIDIA GeForce RTX 4050 running Linux binaries via WSL  these are the results:

~~~
### CUDA

(llama) traversaro@IITBMP014LW012:~/pixiws/llama$ llama-bench -m ~/.cache/llama.cpp/ggml-org_gemma-3-1b-it-GGUF_gemma-3-1b-it-Q4_K_M.gguf
ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
ggml_cuda_init: found 1 CUDA devices:
  Device 0: NVIDIA GeForce RTX 4050 Laptop GPU, compute capability 8.9, VMM: yes
| model                          |       size |     params | backend    | ngl |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | --------------: | -------------------: |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | CUDA       |  99 |           pp512 |     7515.60 ± 189.31 |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | CUDA       |  99 |           tg128 |        117.15 ± 2.45 |

build: c823a55 (137)

### Vulkan on Discrete Nvidia GPU

(llama-vulkan) traversaro@IITBMP014LW012:~/pixiws/llama/llama.cpp-feedstock$ llama-bench -m ~/.cache/llama.cpp/ggml-org_gemma-3-1b-it-GGUF_gemma-3-1b-it-Q4_K_M.gguf
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Microsoft Direct3D12 (NVIDIA GeForce RTX 4050 Laptop GPU) (Dozen) | uma: 0 | fp16: 1 | bf16: 0 | warp size: 32 | shared memory: 32768 | int dot: 1 | matrix cores: none
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | Vulkan,BLAS |      10 |           pp512 |      2820.45 ± 57.78 |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | Vulkan,BLAS |      10 |           tg128 |         78.16 ± 2.94 |


### Vulkan on Integrated Intel GPU

export GGML_VK_VISIBLE_DEVICES=1
(llama-vulkan) traversaro@IITBMP014LW012:~/pixiws/llama/llama.cpp-feedstock$ llama-bench -m ~/.cache/llama.cpp/ggml-org_gemma-3-1b-it-GGUF_gemma-3-1b-it-Q4_K_M.gguf
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Microsoft Direct3D12 (Intel(R) Iris(R) Xe Graphics) (Dozen) | uma: 1 | fp16: 1 | bf16: 0 | warp size: 16 | shared memory: 32768 | int dot: 1 | matrix cores: none
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | Vulkan,BLAS |      10 |           pp512 |       752.84 ± 34.93 |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | Vulkan,BLAS |      10 |           tg128 |         43.39 ± 1.81 |

### CPU 

(llama-vulkan) traversaro@IITBMP014LW012:~/pixiws/llama/llama.cpp-feedstock$ GGML_VK_VISIBLE_DEVICES= llama-bench -m ~/.
cache/llama.cpp/ggml-org_gemma-3-1b-it-GGUF_gemma-3-1b-it-Q4_K_M.gguf
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
ggml_vulkan: Found 0 Vulkan devices:
| model                          |       size |     params | backend    | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | ------: | --------------: | -------------------: |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | Vulkan,BLAS |      10 |           pp512 |        148.64 ± 5.85 |
| gemma3 1B Q4_K - Medium        | 762.49 MiB |   999.89 M | Vulkan,BLAS |      10 |           tg128 |          8.81 ± 0.09 |

build: c823a55 (137)
~~~

In case users want for use cpu for any reason, they can do that by passing `---device none` to `llama-cli` or `llama-server`. 

Thinks to discuss:
* With this change, the `cpu` variant also supports GPU (via Vulkan). So it is ok to keep calling it `cpu`, or should we use another name?
* Even if Nvidia GPU are supported via Vulkan, typically using directly the CUDA backend give better performances, so on system with `__cuda` defined, the cuda package will continue to be installed. For completeness, I also included the Vulkan backend also on CUDA builds, to permit users to easily test them with `--device` option, as the cost is just ~5 MB of size more. However we can also disable.
* Similar point for macOS: I enabled the Vulkan backend on macOS, but by default macOS does not contain any Vulkan-capable driver, so the metal version will continue to be used. Perhaps we can disable Vulkan there? Answer in https://github.com/conda-forge/llama.cpp-feedstock/pull/64#issuecomment-3298844367 .



Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
