### PR TITLE
9596; fix M5 performance; check for llama

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '26.1'
 blas_impl:
 - accelerate
 c_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '26.1'
 blas_impl:
 - accelerate
 c_compiler:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,7 +3,7 @@ azure:
 bot:
   automerge: true
   version_updates:
-    random_fraction_to_keep: 0.02
+    random_fraction_to_keep: 0.2
 conda_build:
   error_overlinking: true
 conda_build_tool: rattler-build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,5 +1,7 @@
-c_stdlib_version:   # [osx and x86_64]
-  - '11.0'          # [osx and x86_64]
+c_stdlib_version:    # [osx]
+  - '11.0'           # [osx]
+MACOSX_SDK_VERSION:  # [osx]
+  - '26.1'           # [osx]
 
 blas_impl:
   - mkl        # [(linux and not aarch64) or win]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: llama.cpp
-  version: "9574"
+  version: "9596"
   build: 0
   # ensure arm_variant_type gets detected as a used variable
   touch_arm_variant_type: ${{ arm_variant_type if (linux and aarch64) else "None" }}
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/ggml-org/${{ name }}/archive/b${{ version ~ "" | split(".") | list | last }}.tar.gz
-  sha256: a482a5d45e291aff8eca06ee3c902f7f4af665a451feeac6dcbb504ab365b420
+  sha256: c80caadf88a211c6d6e7820ded7258a6c2c0a476926a04dd7e8708ba3e552c93
 
 build:
   # See https://conda-forge.org/docs/user/tipsandtricks/#installing-cuda-enabled-packages-like-tensorflow-and-pytorch
@@ -228,6 +228,7 @@ tests:
 
         # Check binaries
           - echo "Checking binary files..."
+          - check_file "$PREFIX/bin/llama" "llama"
           - check_file "$PREFIX/bin/llama-batched" "llama-batched"
           - check_file "$PREFIX/bin/llama-batched-bench" "llama-batched-bench"
           - check_file "$PREFIX/bin/llama-bench" "llama-bench"


### PR DESCRIPTION
We need the newer SDK to support TensorOps on the M5 chips. This makes a massive difference in performance for me. I was getting the following warning:

```
0.00.051.117 E ggml_metal_library_init_from_source: error compiling source
0.00.051.123 W ggml_metal_device_init: - the tensor API is not supported in this environment - disabling
```

If we build with a newer SDK, this vanishes and performance increases. E.g. for `llama-server -hf unsloth/Qwen3.6-27B-MTP-GGUF:Q4_K_M --spec-type draft-mtp --spec-draft-n-max 2` we go from 220t/s (prefill) and 24t/s (decode) to 550t/s (prefill) and 27t/s (decode).

